### PR TITLE
fix: use high specificity css selectors to avoid the use of "!important"

### DIFF
--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -14,21 +14,21 @@
 	margin: $white;
 }
 
-.fl-prefsEditor-separatedPanel .fl-panelBar .fl-prefsEditor-buttons {
-	background: $white !important;
-	border: 1px solid $green-dark !important;
-	border-radius: 0 0 rem(30) rem(30) !important;
-	border-top: 1px solid $white !important;
-	box-shadow: none !important;
-	box-sizing: border-box !important;
-	padding: rem(10) rem(20) !important;
+#defaultContainer .fl-prefsEditor-separatedPanel .fl-panelBar .fl-prefsEditor-buttons {
+	background: $white;
+	border: 1px solid $green-dark;
+	border-radius: 0 0 rem(30) rem(30);
+	border-top: 1px solid $white;
+	box-shadow: none;
+	box-sizing: border-box;
+	padding: rem(10) rem(20);
 
 	button {
-		color: $black !important;
-		font-family: Roboto !important;
-		font-size: rem(16) !important;
-		font-style: normal !important;
-		font-weight: $font-weight-normal !important;
-		line-height: rem(19) !important;
+		color: $black;
+		font-family: Roboto;
+		font-size: rem(16);
+		font-style: normal;
+		font-weight: $font-weight-normal;
+		line-height: rem(19);
 	}
 }


### PR DESCRIPTION
* [X] This pull request has been linted by running `npm run lint` without errors
* [X] This pull request has been tested by running `npm run dev` and reviewing affected routes
* [X] This pull request has been built by running `npm run generate` without errors
* [X] This isn't a duplicate of an existing pull request
